### PR TITLE
Fix some bugs in whitespace handling

### DIFF
--- a/src/lex/cpp.rs
+++ b/src/lex/cpp.rs
@@ -927,6 +927,10 @@ impl<'a> PreProcessor<'a> {
                         Ok(token)
                     }
                 },
+                Ok(Locatable {
+                    data: Token::Whitespace(_),
+                    ..
+                }) => continue,
                 _ => token,
             };
             cpp_tokens.push(token);
@@ -1290,7 +1294,10 @@ impl<'a> PreProcessor<'a> {
     pub fn next_non_whitespace(&mut self) -> Option<CppResult<Token>> {
         loop {
             match self.next() {
-                Some(Ok(Locatable {data: Token::Whitespace(_), location: _})) => continue,
+                Some(Ok(Locatable {
+                    data: Token::Whitespace(_),
+                    location: _,
+                })) => continue,
                 other => break other,
             }
         }

--- a/src/lex/mod.rs
+++ b/src/lex/mod.rs
@@ -653,7 +653,10 @@ impl Lexer {
     pub fn next_non_whitespace(&mut self) -> Option<LexResult<Locatable<Token>>> {
         loop {
             match self.next() {
-                Some(Ok(Locatable {data: Token::Whitespace(_), location: _})) => continue,
+                Some(Ok(Locatable {
+                    data: Token::Whitespace(_),
+                    location: _,
+                })) => continue,
                 other => break other,
             }
         }
@@ -885,7 +888,8 @@ impl Iterator for Lexer {
                         .with(LexError::UnknownToken(x as char))));
                 }
             };
-            self.seen_line_token |= data != Token::Hash;
+            // We've seen a token if this isn't # and this isn't whitespace
+            self.seen_line_token |= data != Token::Hash && !matches!(data, Token::Whitespace(_));
             Some(Ok(Locatable {
                 data,
                 location: self.span(span_start),

--- a/src/parse/mod.rs
+++ b/src/parse/mod.rs
@@ -141,7 +141,10 @@ impl<I: Lexer> Parser<I> {
     fn __impl_next_token(&mut self) -> Option<Locatable<Token>> {
         loop {
             match self.tokens.next() {
-                Some(Ok(Locatable {data: Token::Whitespace(_), location: _})) => continue,
+                Some(Ok(Locatable {
+                    data: Token::Whitespace(_),
+                    location: _,
+                })) => continue,
                 Some(Ok(mut token)) => {
                     self.last_location = token.location;
                     // This is _such_ a hack


### PR DESCRIPTION
- Don't set `seen_line_token` for whitespace
- Ignore whitespace in `#if` expressions (since the parser doesn't know
what whitespace is)
- Run `cargo fmt`